### PR TITLE
feat(swl): prevent exceeding pi-hole replica count

### DIFF
--- a/software-layer/k8s/apps/base/pi-hole/resources/deployments.yaml
+++ b/software-layer/k8s/apps/base/pi-hole/resources/deployments.yaml
@@ -5,7 +5,11 @@ metadata:
     app: pi-hole
   name: pi-hole
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
   selector:
     matchLabels:
       app: pi-hole


### PR DESCRIPTION
Do not surge past defined replica count during rolling updates because podAntiAffinity can prevent new pods from being scheduled.