### PR TITLE
fix(pfl): remove talos-cluster provider version

### DIFF
--- a/platform-layer/terraform/modules/talos-cluster/main.tf
+++ b/platform-layer/terraform/modules/talos-cluster/main.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     talos = {
       source  = "siderolabs/talos"
-      version = "0.9.0-alpha.0"
     }
   }
 }


### PR DESCRIPTION
Instead of constraining provider versions in the module, rely on the version in main.tf and lock file.